### PR TITLE
Update evdev v0.7.0

### DIFF
--- a/net.lutris.Lutris.json
+++ b/net.lutris.Lutris.json
@@ -48,8 +48,8 @@
       ],
       "sources": [{
         "type": "archive",
-        "url": "https://pypi.python.org/packages/0c/53/f9eb749a2625f45bbc26127c7ee7e4c0eb5d7e4f20f55055a5fb419c27ad/evdev-0.6.4.tar.gz",
-        "sha256": "5268744d8493c273614036cf6423fa175952c64fc1d8d265210e48a4437a6af2"
+        "url": "https://pypi.python.org/packages/67/15/eac376f3e1fc1960a54439c21459b2582e68340001aff83b4ace9e5bd110/evdev-0.7.0.tar.gz",
+        "sha256": "57edafc469a414f58b51af1bfb9ee2babb9f626dd2df530d71c1176871850aa1"
       }]
     },
     {


### PR DESCRIPTION
    InputDevice now accepts objects that support the path protocol. For example:

    pth = pathlib.Path('/dev/input/event0')
    dev = evdev.InputDevice(pth)

    Support path protocol in InputDevice. This means that InputDevice instances can be passed to callers that expect a os.PathLike object.

    Exceptions raised during InputDevice.async_read() (and similar) are now handled properly (i.e. an exception is set on the returned future instead of leaking that exception into the event loop) (Fixes `#67`_).